### PR TITLE
Minor Comments

### DIFF
--- a/exercise 5/javascript/script.js
+++ b/exercise 5/javascript/script.js
@@ -1,6 +1,7 @@
 (function () {
     'use strict';
 
+    // Als je je pagina laad zie je nog alle elementen, het is mooi om dit met JS alvast allemaal op display: none;, en je startpagina op display: block; te zetten.
     
 	var app = {
 		init: function () {
@@ -19,13 +20,14 @@
 			window.addEventListener('hashchange', function (event) {
 				console.log(event);
 
-				this.newUrl = event.newURL.split('#');
-				this.oldUrl = event.oldURL.split('#');
+				this.newUrl = event.newURL.split('#'); // Als je document.querySelector(‘’); gebruikt hoef je je hash niet te slicen
+				this.oldUrl = event.oldURL.split('#'); // Je kan ook window.location.hash gebruiken.
 
-				this.newHash = this.newUrl[1];
+				this.newHash = this.newUrl[1]; 
 				console.log('newHash: ' + this.newHash);
 
-				this.oldHash = oldUrl[1];
+				this.oldHash = oldUrl[1]; // Je zou door al je artikellen kunnen loopen en deze allemaal op display none zetten als ze niet gelijk zijn aan de ‘newHash’. Zo hoef je je 'oldHash' niet meer op te halen.
+
 				console.log('oldHash: ' + this.oldHash);
 
 				sections.toggle(oldHash, newHash);
@@ -42,7 +44,7 @@
 
 
 			// Oldroute uitzetten
-			if (oldHash) {
+			if (oldHash) { // Check op je old hash is netjes
 
 				oldHashElement = document.getElementById(oldHash);
 				oldHashElement.classList.add('hidden');


### PR DESCRIPTION
Hoi Leander, 
Hier wat feedback wat je zou kunnen overwegen.

Als je document.querySelector(‘’); gebruikt hoef je je hash niet te slicen
Je kan ook window.location.hash
Je zou door al je artikellen kunnen loopen en deze allemaal op display none zetten als ze niet gelijk zijn aan de ‘newHash’. Zo hoef je je oude hash niet meer op te halen.
Check op je old hash is netjes
Als je je pagina laad zie je nog alle elementen, het is mooi om dit met JS alvast allemaal op display: none;, en je startpagina op display: block; te zetten.

Het staat als comments in je code (ik moest iets veranderen)